### PR TITLE
Bump version 1.7.0 to 1.8.0, bump template version 1.7.0 to 1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.molgenis</groupId>
   <artifactId>vip-report</artifactId>
-  <version>1.7.0</version>
+  <version>1.8.0</version>
 
   <name>vip-report</name>
   <description>Report generator for Variant Call Format (VCF) files</description>
@@ -43,7 +43,7 @@
     <samtools.htsjdk.version>2.21.3</samtools.htsjdk.version>
     <download-maven-plugin.version>1.6.0</download-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
-    <vip.report.template.version>1.7.0</vip.report.template.version>
+    <vip.report.template.version>1.8.0</vip.report.template.version>
     <phenopackets.version>1.0.0</phenopackets.version>
   </properties>
 


### PR DESCRIPTION
Bump vip.report.template.version 1.7.0 to 1.8.0