### PR TITLE
chore:bump vip.report.template.version 3.1.2 to 3.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.2</version>
+    <version>2.7.3</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 
   <groupId>org.molgenis</groupId>
   <artifactId>vip-report</artifactId>
-  <version>4.1.2</version>
+  <version>4.1.3</version>
 
   <name>vip-report</name>
   <description>Report generator for Variant Call Format (VCF) files</description>
@@ -43,7 +43,7 @@
     <samtools.htsjdk.version>2.21.3</samtools.htsjdk.version>
     <download-maven-plugin.version>1.6.7</download-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
-    <vip.report.template.version>3.1.2</vip.report.template.version>
+    <vip.report.template.version>3.1.3</vip.report.template.version>
     <phenopackets.version>1.0.0</phenopackets.version>
     <opencsv.version>5.2</opencsv.version>
   </properties>


### PR DESCRIPTION
chore:bump spring-boot-starter-parent 2.6.2 to 2.7.3 (fixes security vulnerabilities)
chore:bump vip-report 4.1.2 to 4.1.3